### PR TITLE
[feat][venue] 공연장 도메인 presentation 계층 구현

### DIFF
--- a/src/main/java/com/firstticket/venueservice/application/dto/command/SectionCreationInfo.java
+++ b/src/main/java/com/firstticket/venueservice/application/dto/command/SectionCreationInfo.java
@@ -1,0 +1,17 @@
+package com.firstticket.venueservice.application.dto.command;
+
+import com.firstticket.venueservice.domain.SeatType;
+
+/**
+ * 공연장 일괄 생성 시 구역 정보를 담는 내부 DTO.
+ * CreateSectionCommand와 달리 venueId를 포함하지 않는다.
+ * venueId는 createVenueWithSections() 내부에서 venue 저장 후 자동으로 연결된다.
+ */
+public record SectionCreationInfo(
+    String name,
+    SeatType type,
+    Integer rowCount,
+    Integer colCount,
+    Integer capacity
+) {
+}

--- a/src/main/java/com/firstticket/venueservice/application/service/VenueCommandService.java
+++ b/src/main/java/com/firstticket/venueservice/application/service/VenueCommandService.java
@@ -75,6 +75,7 @@ public class VenueCommandService {
         Venue venue = Venue.create(venueCommand.name(), venueCommand.address());
         venueRepository.save(venue);
 
+        List<Section> seatedSections = new java.util.ArrayList<>();
         // 구역 추가 — 각 구역의 커맨드를 venueId로 재구성
         if (sectionCommands != null && !sectionCommands.isEmpty()) {
             for (CreateSectionCommand sectionCommand : sectionCommands) {
@@ -94,12 +95,14 @@ public class VenueCommandService {
                     withVenueId.colCount(),
                     withVenueId.capacity()
                 );
-                // SEATED 타입: VenueSeat 일괄 생성
-                if (sectionCommand.type() == SeatType.SEATED) {
-                    venueSeatRepository.saveAll(createSeats(section));
+                if (section.getType() == SeatType.SEATED) {
+                    seatedSections.add(section);
                 }
             }
             venueRepository.save(venue);
+            for (Section section : seatedSections) {
+                venueSeatRepository.saveAll(createSeats(section));
+            }
         }
 
         return VenueResult.from(venue);

--- a/src/main/java/com/firstticket/venueservice/application/service/VenueCommandService.java
+++ b/src/main/java/com/firstticket/venueservice/application/service/VenueCommandService.java
@@ -59,6 +59,52 @@ public class VenueCommandService {
         return VenueResult.from(venueRepository.save(venue));
     }
 
+    /**
+     * 공연장 + 구역 일괄 생성.
+     * 단일 트랜잭션 안에서 공연장 생성 → 구역 추가 → VenueSeat 생성을 처리한다.
+     * Controller에서 분산된 호출을 하나로 통합하여 partial commit 방지.
+     */
+    @Transactional
+    public VenueResult createVenueWithSections(UUID requesterId,
+        CreateVenueCommand venueCommand,
+        List<CreateSectionCommand> sectionCommands) {
+        validateRequesterId(requesterId);
+        validateCreateVenueCommand(venueCommand);
+
+        // 공연장 생성
+        Venue venue = Venue.create(venueCommand.name(), venueCommand.address());
+        venueRepository.save(venue);
+
+        // 구역 추가 — 각 구역의 커맨드를 venueId로 재구성
+        if (sectionCommands != null && !sectionCommands.isEmpty()) {
+            for (CreateSectionCommand sectionCommand : sectionCommands) {
+                CreateSectionCommand withVenueId = new CreateSectionCommand(
+                    venue.getId(),           // ← 저장된 venueId 주입
+                    sectionCommand.name(),
+                    sectionCommand.type(),
+                    sectionCommand.rowCount(),
+                    sectionCommand.colCount(),
+                    sectionCommand.capacity()
+                );
+                validateCreateSectionCommand(withVenueId);
+                Section section = venue.addSection(
+                    withVenueId.type(),
+                    withVenueId.name(),
+                    withVenueId.rowCount(),
+                    withVenueId.colCount(),
+                    withVenueId.capacity()
+                );
+                // SEATED 타입: VenueSeat 일괄 생성
+                if (sectionCommand.type() == SeatType.SEATED) {
+                    venueSeatRepository.saveAll(createSeats(section));
+                }
+            }
+            venueRepository.save(venue);
+        }
+
+        return VenueResult.from(venue);
+    }
+
     // -------- 공연장 수정 -----------------------------------------
 
     /**

--- a/src/main/java/com/firstticket/venueservice/application/service/VenueCommandService.java
+++ b/src/main/java/com/firstticket/venueservice/application/service/VenueCommandService.java
@@ -1,5 +1,8 @@
 package com.firstticket.venueservice.application.service;
 
+import static com.firstticket.venueservice.domain.SeatType.*;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -10,6 +13,7 @@ import com.firstticket.common.exception.BusinessException;
 import com.firstticket.common.response.CommonErrorCode;
 import com.firstticket.venueservice.application.dto.command.CreateSectionCommand;
 import com.firstticket.venueservice.application.dto.command.CreateVenueCommand;
+import com.firstticket.venueservice.application.dto.command.SectionCreationInfo;
 import com.firstticket.venueservice.application.dto.command.UpdateVenueCommand;
 import com.firstticket.venueservice.application.dto.command.UpdateVenueSeatStatusCommand;
 import com.firstticket.venueservice.application.dto.result.VenueResult;
@@ -64,50 +68,56 @@ public class VenueCommandService {
      * 단일 트랜잭션 안에서 공연장 생성 → 구역 추가 → VenueSeat 생성을 처리한다.
      * Controller에서 분산된 호출을 하나로 통합하여 partial commit 방지.
      */
+    /**
+     * 공연장 + 구역 일괄 생성.
+     * 단일 트랜잭션 안에서 공연장 생성 → 구역 추가 → VenueSeat 생성을 처리한다.
+     * Controller에서 분산된 호출을 하나로 통합하여 partial commit을 방지한다.
+     */
     @Transactional
     public VenueResult createVenueWithSections(UUID requesterId,
         CreateVenueCommand venueCommand,
-        List<CreateSectionCommand> sectionCommands) {
+        List<SectionCreationInfo> sections) {
         validateRequesterId(requesterId);
         validateCreateVenueCommand(venueCommand);
 
-        // 공연장 생성
+        // 공연장 생성 및 저장
         Venue venue = Venue.create(venueCommand.name(), venueCommand.address());
         venueRepository.save(venue);
 
-        List<Section> seatedSections = new java.util.ArrayList<>();
-        // 구역 추가 — 각 구역의 커맨드를 venueId로 재구성
-        if (sectionCommands != null && !sectionCommands.isEmpty()) {
-            for (CreateSectionCommand sectionCommand : sectionCommands) {
-                CreateSectionCommand withVenueId = new CreateSectionCommand(
-                    venue.getId(),           // ← 저장된 venueId 주입
-                    sectionCommand.name(),
-                    sectionCommand.type(),
-                    sectionCommand.rowCount(),
-                    sectionCommand.colCount(),
-                    sectionCommand.capacity()
-                );
-                validateCreateSectionCommand(withVenueId);
-                Section section = venue.addSection(
-                    withVenueId.type(),
-                    withVenueId.name(),
-                    withVenueId.rowCount(),
-                    withVenueId.colCount(),
-                    withVenueId.capacity()
-                );
-                if (section.getType() == SeatType.SEATED) {
-                    seatedSections.add(section);
-                }
+        // 구역이 없으면 공연장만 반환
+        if (sections == null || sections.isEmpty()) {
+            return VenueResult.from(venue);
+        }
+
+        // 구역 추가 및 SEATED 타입 VenueSeat 일괄 생성
+        List<VenueSeat> seatsToSave = new ArrayList<>();
+
+        for (SectionCreationInfo info : sections) {
+            validateSectionCreationInfo(info);
+
+            // venue.addSection()이 Venue 객체를 직접 참조하므로
+            // venueId를 별도로 주입할 필요 없음
+            Section section = venue.addSection(
+                info.type(),
+                info.name(),
+                info.rowCount(),
+                info.colCount(),
+                info.capacity()
+            );
+
+            if (info.type() == SEATED) {
+                seatsToSave.addAll(createSeats(section));
             }
-            venueRepository.save(venue);
-            for (Section section : seatedSections) {
-                venueSeatRepository.saveAll(createSeats(section));
-            }
+        }
+
+        venueRepository.save(venue);
+
+        if (!seatsToSave.isEmpty()) {
+            venueSeatRepository.saveAll(seatsToSave);
         }
 
         return VenueResult.from(venue);
     }
-
     // -------- 공연장 수정 -----------------------------------------
 
     /**
@@ -183,7 +193,7 @@ public class VenueCommandService {
         venueRepository.save(venue);
 
         // SEATED 타입: rowCount × colCount 개 VenueSeat 일괄 생성 (V-02)
-        if (command.type() == SeatType.SEATED) {
+        if (command.type() == SEATED) {
             List<VenueSeat> seats = createSeats(section);
             venueSeatRepository.saveAll(seats);
         }
@@ -213,7 +223,7 @@ public class VenueCommandService {
             .filter(s -> s.getId().equals(sectionId))
             .findFirst()
             .ifPresent(section -> {
-                if (section.getType() == SeatType.SEATED) {
+                if (section.getType() == SEATED) {
                     venueSeatRepository.deleteAllBySectionId(sectionId);
                 }
             });
@@ -341,6 +351,38 @@ public class VenueCommandService {
         }
         if (command.address() == null || command.address().isBlank()) {
             throw new VenueException(VenueErrorCode.INVALID_VENUE_ADDRESS);
+        }
+    }
+
+    /**
+     * 구역 생성 정보 검증.
+     * validateCreateSectionCommand()와 동일한 규칙을 적용한다.
+     */
+    private void validateSectionCreationInfo(SectionCreationInfo info) {
+        if (info.name() == null || info.name().isBlank()) {
+            throw new VenueException(VenueErrorCode.INVALID_SECTION_NAME);
+        }
+        if (info.type() == null) {
+            throw new VenueException(VenueErrorCode.INVALID_SECTION_TYPE);
+        }
+        switch (info.type()) {
+            case SEATED -> {
+                if (info.rowCount() == null || info.colCount() == null
+                    || info.rowCount() <= 0 || info.colCount() <= 0) {
+                    throw new VenueException(VenueErrorCode.INVALID_SEAT_COUNT);
+                }
+                if (info.capacity() != null) {
+                    throw new VenueException(VenueErrorCode.INVALID_SECTION_FIELD_COMBINATION);
+                }
+            }
+            case STANDING, FREE -> {
+                if (info.capacity() == null || info.capacity() <= 0) {
+                    throw new VenueException(VenueErrorCode.INVALID_CAPACITY);
+                }
+                if (info.rowCount() != null || info.colCount() != null) {
+                    throw new VenueException(VenueErrorCode.INVALID_SECTION_FIELD_COMBINATION);
+                }
+            }
         }
     }
 

--- a/src/main/java/com/firstticket/venueservice/application/service/VenueQueryService.java
+++ b/src/main/java/com/firstticket/venueservice/application/service/VenueQueryService.java
@@ -141,6 +141,40 @@ public class VenueQueryService {
     }
 
     /**
+     * 구역이 해당 공연장에 속하는지 검증한다.
+     * getSeats, getSeat, updateSeatStatus 호출 전 계층 관계를 확인한다.
+     */
+    public void validateSectionBelongsToVenue(UUID venueId, UUID sectionId) {
+        VenueResult venue = getVenue(venueId);
+        boolean belongs = venue.sections().stream()
+            .anyMatch(s -> s.id().equals(sectionId));
+        if (!belongs) {
+            throw new VenueException(VenueErrorCode.SECTION_NOT_FOUND);
+        }
+    }
+
+    /**
+     * 좌석이 해당 구역에 속하는지 검증한다.
+     */
+    public void validateSeatBelongsToSection(UUID sectionId, UUID seatId) {
+        VenueSeatResult seat = getSeat(seatId);
+        if (!seat.sectionId().equals(sectionId)) {
+            throw new VenueException(VenueErrorCode.SEAT_NOT_FOUND);
+        }
+    }
+
+    /**
+     * 공연장 존재 여부 확인.
+     * VenueInternalController에서 사용한다.
+     * Presentation 계층이 VenueRepository에 직접 의존하지 않도록 격리한다.
+     */
+    public void validateVenueExists(UUID venueId) {
+        if (!venueRepository.existsById(venueId)) {
+            throw new VenueException(VenueErrorCode.VENUE_NOT_FOUND);
+        }
+    }
+
+    /**
      * 목록 조회 쿼리 검증.
      * pageSize, pageNumber 범위 검증.
      */

--- a/src/main/java/com/firstticket/venueservice/presentation/VenueController.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/VenueController.java
@@ -1,0 +1,324 @@
+package com.firstticket.venueservice.presentation;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.firstticket.common.exception.BusinessException;
+import com.firstticket.common.response.ApiResponse;
+import com.firstticket.common.response.CommonErrorCode;
+import com.firstticket.common.web.AuthContext;
+import com.firstticket.common.web.UserRole;
+import com.firstticket.venueservice.application.dto.command.UpdateVenueSeatStatusCommand;
+import com.firstticket.venueservice.application.dto.result.VenueResult;
+import com.firstticket.venueservice.application.dto.result.VenueSeatResult;
+import com.firstticket.venueservice.application.dto.result.VenueSummaryResult;
+import com.firstticket.venueservice.application.service.VenueCommandService;
+import com.firstticket.venueservice.application.service.VenueQueryService;
+import com.firstticket.venueservice.domain.query.PagedResult;
+import com.firstticket.venueservice.presentation.dto.request.CreateSectionRequest;
+import com.firstticket.venueservice.presentation.dto.request.CreateVenueRequest;
+import com.firstticket.venueservice.presentation.dto.request.SearchVenueRequest;
+import com.firstticket.venueservice.presentation.dto.request.UpdateSeatStatusRequest;
+import com.firstticket.venueservice.presentation.dto.request.UpdateVenueRequest;
+import com.firstticket.venueservice.presentation.dto.response.PagedResponse;
+import com.firstticket.venueservice.presentation.dto.response.SectionResponse;
+import com.firstticket.venueservice.presentation.dto.response.VenueResponse;
+import com.firstticket.venueservice.presentation.dto.response.VenueSeatResponse;
+import com.firstticket.venueservice.presentation.dto.response.VenueSummaryResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 공연장 도메인 Controller.
+ *
+ * 인가 처리:
+ * Gateway가 주입한 X-User-Id, X-User-Role 헤더를
+ * AuthContext로 추출하여 역할 검증을 수행한다.
+ * HOST·ADMIN 검증은 Controller 계층에서 처리한다.
+ * 소유자(createdBy) 검증은 Application 계층에서 처리한다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/venues")
+public class VenueController {
+
+    private final VenueCommandService venueCommandService;
+    private final VenueQueryService venueQueryService;
+
+    // ----- 공연장 CRUD --------------------------------------
+
+    /**
+     * 공연장 등록 (POST /api/venues).
+     * 권한: ADMIN, HOST
+     * sections 배열을 함께 전달하면 구역과 VenueSeat이 자동 생성된다 (V-01, V-02).
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<VenueResponse>> createVenue(
+        @RequestBody @Valid CreateVenueRequest request) {
+        checkHostOrAdmin();
+        UUID requesterId = AuthContext.getUserId();
+
+        // 공연장 먼저 생성
+        VenueResult venueResult = venueCommandService.createVenue(
+            requesterId, request.toCommand()
+        );
+
+        // sections가 있으면 구역 추가 (V-01, V-02)
+        if (request.sections() != null && !request.sections().isEmpty()) {
+            for (CreateVenueRequest.SectionRequest sectionRequest : request.sections()) {
+                venueCommandService.createSection(
+                    requesterId,
+                    sectionRequest.toCommand(venueResult.id())
+                );
+            }
+            // 구역 추가 후 sections 포함된 Venue 재조회
+            venueResult = venueQueryService.getVenue(venueResult.id());
+        }
+
+        return ApiResponse.success(
+            VenueSuccessCode.VENUE_CREATED,
+            VenueResponse.from(venueResult)
+        );
+    }
+
+    /**
+     * 공연장 목록 조회 (GET /api/venues).
+     * 권한: ALL
+     * 이름·주소 키워드 검색, 정렬, 페이지네이션 지원.
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<PagedResponse<VenueSummaryResponse>>> searchVenues(
+        @ModelAttribute SearchVenueRequest request) {
+        PagedResult<VenueSummaryResult> pagedResult =
+            venueQueryService.searchVenues(request.toQuery());
+
+        return ApiResponse.success(
+            VenueSuccessCode.VENUE_LIST_FOUND,
+            PagedResponse.from(pagedResult, VenueSummaryResponse::from)
+        );
+    }
+
+    /**
+     * 공연장 상세 조회 (GET /api/venues/{venueId}).
+     * 권한: ALL
+     * 공연장 기본 정보 + 구역 목록 반환.
+     */
+    @GetMapping("/{venueId}")
+    public ResponseEntity<ApiResponse<VenueResponse>> getVenue(
+        @PathVariable UUID venueId) {
+        VenueResult result = venueQueryService.getVenue(venueId);
+        return ApiResponse.success(
+            VenueSuccessCode.VENUE_FOUND,
+            VenueResponse.from(result)
+        );
+    }
+
+    /**
+     * 공연장 수정 (PATCH /api/venues/{venueId}).
+     * 권한: ADMIN, HOST
+     * null이면 기존 값 유지 (부분 업데이트).
+     */
+    @PatchMapping("/{venueId}")
+    public ResponseEntity<ApiResponse<VenueResponse>> updateVenue(
+        @PathVariable UUID venueId,
+        @RequestBody UpdateVenueRequest request) {
+        checkHostOrAdmin();
+        UUID requesterId = AuthContext.getUserId();
+
+        VenueResult result = venueCommandService.updateVenue(
+            requesterId, request.toCommand(venueId)
+        );
+        return ApiResponse.success(
+            VenueSuccessCode.VENUE_UPDATED,
+            VenueResponse.from(result)
+        );
+    }
+
+    /**
+     * 공연장 삭제 (DELETE /api/venues/{venueId}).
+     * 권한: ADMIN
+     * 사전 조건: 해당 공연장에 등록된 프로그램이 없어야 한다.
+     */
+    @DeleteMapping("/{venueId}")
+    public ResponseEntity<ApiResponse<Void>> deleteVenue(
+        @PathVariable UUID venueId) {
+        checkAdmin();
+        UUID requesterId = AuthContext.getUserId();
+
+        venueCommandService.deleteVenue(requesterId, venueId);
+        return ApiResponse.success(VenueSuccessCode.VENUE_DELETED);
+    }
+
+    // ---- 구역 -----------------------------------------------------
+
+    /**
+     * 구역 등록 (POST /api/venues/{venueId}/sections).
+     * 권한: ADMIN, HOST
+     * SEATED 타입: VenueSeat 자동 생성 (V-02).
+     */
+    @PostMapping("/{venueId}/sections")
+    public ResponseEntity<ApiResponse<VenueResponse>> createSection(
+        @PathVariable UUID venueId,
+        @RequestBody @Valid CreateSectionRequest request) {
+        checkHostOrAdmin();
+        UUID requesterId = AuthContext.getUserId();
+
+        VenueResult result = venueCommandService.createSection(
+            requesterId, request.toCommand(venueId)
+        );
+        return ApiResponse.success(
+            VenueSuccessCode.SECTION_CREATED,
+            VenueResponse.from(result)
+        );
+    }
+
+    /**
+     * 구역 목록 조회 (GET /api/venues/{venueId}/sections).
+     * 권한: ALL
+     * 공연장 상세 조회에 sections가 포함되므로 getVenue()로 대체한다.
+     */
+    @GetMapping("/{venueId}/sections")
+    public ResponseEntity<ApiResponse<List<SectionResponse>>> getSections(
+        @PathVariable UUID venueId) {
+        VenueResult result = venueQueryService.getVenue(venueId);
+        return ApiResponse.success(
+            VenueSuccessCode.SECTION_LIST_FOUND,
+            result.sections().stream()
+                .map(SectionResponse::from)
+                .toList()
+        );
+    }
+
+    /**
+     * 구역 상세 조회 (GET /api/venues/{venueId}/sections/{sectionId}).
+     * 권한: ALL
+     */
+    @GetMapping("/{venueId}/sections/{sectionId}")
+    public ResponseEntity<ApiResponse<SectionResponse>> getSection(
+        @PathVariable UUID venueId,
+        @PathVariable UUID sectionId) {
+        VenueResult venue = venueQueryService.getVenue(venueId);
+        SectionResponse section = venue.sections().stream()
+            .filter(s -> s.id().equals(sectionId))
+            .map(SectionResponse::from)
+            .findFirst()
+            .orElseThrow(() ->
+                new com.firstticket.venueservice.domain.exception.VenueException(
+                    com.firstticket.venueservice.domain.exception.VenueErrorCode.SECTION_NOT_FOUND
+                ));
+        return ApiResponse.success(VenueSuccessCode.SECTION_FOUND, section);
+    }
+
+    /**
+     * 구역 삭제 (DELETE /api/venues/{venueId}/sections/{sectionId}).
+     * 권한: ADMIN
+     * SEATED 타입: 연관 VenueSeat 일괄 삭제 후 구역 삭제.
+     * 수정 API 없음 — 삭제 후 재등록 방식 사용.
+     */
+    @DeleteMapping("/{venueId}/sections/{sectionId}")
+    public ResponseEntity<ApiResponse<Void>> deleteSection(
+        @PathVariable UUID venueId,
+        @PathVariable UUID sectionId) {
+        checkAdmin();
+        UUID requesterId = AuthContext.getUserId();
+
+        venueCommandService.deleteSection(requesterId, venueId, sectionId);
+        return ApiResponse.success(VenueSuccessCode.SECTION_DELETED);
+    }
+
+    // ---- 좌석 -----------------------------------------------------
+
+    /**
+     * 구역 내 좌석 목록 조회 (GET /api/venues/{venueId}/sections/{sectionId}/seats).
+     * 권한: ALL
+     * SEATED 타입만 VenueSeat이 존재한다.
+     * STANDING·FREE 타입은 빈 리스트를 반환한다.
+     */
+    @GetMapping("/{venueId}/sections/{sectionId}/seats")
+    public ResponseEntity<ApiResponse<List<VenueSeatResponse>>> getSeats(
+        @PathVariable UUID venueId,
+        @PathVariable UUID sectionId) {
+        List<VenueSeatResult> results = venueQueryService.getSeatsBySection(sectionId);
+        return ApiResponse.success(
+            VenueSuccessCode.SEAT_LIST_FOUND,
+            results.stream().map(VenueSeatResponse::from).toList()
+        );
+    }
+
+    /**
+     * 좌석 상세 조회 (GET /api/venues/{venueId}/sections/{sectionId}/seats/{seatId}).
+     * 권한: ALL
+     */
+    @GetMapping("/{venueId}/sections/{sectionId}/seats/{seatId}")
+    public ResponseEntity<ApiResponse<VenueSeatResponse>> getSeat(
+        @PathVariable UUID venueId,
+        @PathVariable UUID sectionId,
+        @PathVariable UUID seatId) {
+        VenueSeatResult result = venueQueryService.getSeat(seatId);
+        return ApiResponse.success(
+            VenueSuccessCode.SEAT_FOUND,
+            VenueSeatResponse.from(result)
+        );
+    }
+
+    /**
+     * 좌석 물리 상태 변경 (PATCH /api/venues/{venueId}/sections/{sectionId}/seats/{seatId}/status).
+     * 권한: ADMIN
+     * AVAILABLE ↔ BROKEN 전환.
+     * BROKEN 상태의 좌석은 예매 불가 처리된다 (V-05).
+     */
+    @PatchMapping("/{venueId}/sections/{sectionId}/seats/{seatId}/status")
+    public ResponseEntity<ApiResponse<VenueSeatResponse>> updateSeatStatus(
+        @PathVariable UUID venueId,
+        @PathVariable UUID sectionId,
+        @PathVariable UUID seatId,
+        @RequestBody @Valid UpdateSeatStatusRequest request) {
+        checkAdmin();
+        UUID requesterId = AuthContext.getUserId();
+
+        UpdateVenueSeatStatusCommand command = request.toCommand(seatId);
+        VenueSeatResult result = command.broken()
+            ? venueCommandService.markSeatBroken(requesterId, command)
+            : venueCommandService.restoreSeat(requesterId, command);
+
+        return ApiResponse.success(
+            VenueSuccessCode.SEAT_STATUS_UPDATED,
+            VenueSeatResponse.from(result)
+        );
+    }
+
+    // --- 권한 검증 헬퍼 -----------------------------------
+
+    /**
+     * HOST 또는 ADMIN 역할인지 검증한다.
+     */
+    private void checkHostOrAdmin() {
+        UserRole role = AuthContext.getRole();
+        if (role != UserRole.HOST && role != UserRole.ADMIN) {
+            throw new BusinessException(CommonErrorCode.FORBIDDEN);
+        }
+    }
+
+    /**
+     * ADMIN 역할인지 검증한다.
+     * 공연장 삭제·구역 삭제·좌석 상태 변경은 ADMIN만 허용한다.
+     */
+    private void checkAdmin() {
+        UserRole role = AuthContext.getRole();
+        if (role != UserRole.ADMIN) {
+            throw new BusinessException(CommonErrorCode.FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/VenueController.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/VenueController.java
@@ -52,7 +52,7 @@ import lombok.RequiredArgsConstructor;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/venues")
+@RequestMapping("/api/v1/venues")
 public class VenueController {
 
     private final VenueCommandService venueCommandService;

--- a/src/main/java/com/firstticket/venueservice/presentation/VenueController.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/VenueController.java
@@ -19,6 +19,7 @@ import com.firstticket.common.response.ApiResponse;
 import com.firstticket.common.response.CommonErrorCode;
 import com.firstticket.common.web.AuthContext;
 import com.firstticket.common.web.UserRole;
+import com.firstticket.venueservice.application.dto.command.CreateSectionCommand;
 import com.firstticket.venueservice.application.dto.command.UpdateVenueSeatStatusCommand;
 import com.firstticket.venueservice.application.dto.result.VenueResult;
 import com.firstticket.venueservice.application.dto.result.VenueSeatResult;
@@ -70,26 +71,20 @@ public class VenueController {
         checkHostOrAdmin();
         UUID requesterId = AuthContext.getUserId();
 
-        // 공연장 먼저 생성
-        VenueResult venueResult = venueCommandService.createVenue(
-            requesterId, request.toCommand()
-        );
+        // 단일 트랜잭션으로 공연장 + 구역 일괄 생성 — partial commit 방지
+        List<CreateSectionCommand> sectionCommands = request.sections() == null
+            ? List.of()
+            : request.sections().stream()
+            .map(s -> s.toCommand(UUID.randomUUID()))
+            .toList();
 
-        // sections가 있으면 구역 추가 (V-01, V-02)
-        if (request.sections() != null && !request.sections().isEmpty()) {
-            for (CreateVenueRequest.SectionRequest sectionRequest : request.sections()) {
-                venueCommandService.createSection(
-                    requesterId,
-                    sectionRequest.toCommand(venueResult.id())
-                );
-            }
-            // 구역 추가 후 sections 포함된 Venue 재조회
-            venueResult = venueQueryService.getVenue(venueResult.id());
-        }
+        VenueResult result = venueCommandService.createVenueWithSections(
+            requesterId, request.toCommand(), sectionCommands
+        );
 
         return ApiResponse.success(
             VenueSuccessCode.VENUE_CREATED,
-            VenueResponse.from(venueResult)
+            VenueResponse.from(result)
         );
     }
 
@@ -100,7 +95,7 @@ public class VenueController {
      */
     @GetMapping
     public ResponseEntity<ApiResponse<PagedResponse<VenueSummaryResponse>>> searchVenues(
-        @ModelAttribute SearchVenueRequest request) {
+        @ModelAttribute @Valid SearchVenueRequest request) {
         PagedResult<VenueSummaryResult> pagedResult =
             venueQueryService.searchVenues(request.toQuery());
 
@@ -250,6 +245,7 @@ public class VenueController {
     public ResponseEntity<ApiResponse<List<VenueSeatResponse>>> getSeats(
         @PathVariable UUID venueId,
         @PathVariable UUID sectionId) {
+        venueQueryService.validateSectionBelongsToVenue(venueId, sectionId);
         List<VenueSeatResult> results = venueQueryService.getSeatsBySection(sectionId);
         return ApiResponse.success(
             VenueSuccessCode.SEAT_LIST_FOUND,
@@ -266,6 +262,8 @@ public class VenueController {
         @PathVariable UUID venueId,
         @PathVariable UUID sectionId,
         @PathVariable UUID seatId) {
+        venueQueryService.validateSectionBelongsToVenue(venueId, sectionId);
+        venueQueryService.validateSeatBelongsToSection(sectionId, seatId);
         VenueSeatResult result = venueQueryService.getSeat(seatId);
         return ApiResponse.success(
             VenueSuccessCode.SEAT_FOUND,
@@ -285,6 +283,9 @@ public class VenueController {
         @PathVariable UUID sectionId,
         @PathVariable UUID seatId,
         @RequestBody @Valid UpdateSeatStatusRequest request) {
+        venueQueryService.validateSectionBelongsToVenue(venueId, sectionId);
+        venueQueryService.validateSeatBelongsToSection(sectionId, seatId);
+
         checkAdmin();
         UUID requesterId = AuthContext.getUserId();
 

--- a/src/main/java/com/firstticket/venueservice/presentation/VenueController.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/VenueController.java
@@ -19,7 +19,7 @@ import com.firstticket.common.response.ApiResponse;
 import com.firstticket.common.response.CommonErrorCode;
 import com.firstticket.common.web.AuthContext;
 import com.firstticket.common.web.UserRole;
-import com.firstticket.venueservice.application.dto.command.CreateSectionCommand;
+import com.firstticket.venueservice.application.dto.command.SectionCreationInfo;
 import com.firstticket.venueservice.application.dto.command.UpdateVenueSeatStatusCommand;
 import com.firstticket.venueservice.application.dto.result.VenueResult;
 import com.firstticket.venueservice.application.dto.result.VenueSeatResult;
@@ -71,15 +71,16 @@ public class VenueController {
         checkHostOrAdmin();
         UUID requesterId = AuthContext.getUserId();
 
-        // 단일 트랜잭션으로 공연장 + 구역 일괄 생성 — partial commit 방지
-        List<CreateSectionCommand> sectionCommands = request.sections() == null
+        List<SectionCreationInfo> sections = request.sections() == null
             ? List.of()
             : request.sections().stream()
-            .map(s -> s.toCommand(UUID.randomUUID()))
+            .map(s -> new SectionCreationInfo(
+                s.name(), s.type(),
+                s.rowCount(), s.colCount(), s.capacity()))
             .toList();
 
         VenueResult result = venueCommandService.createVenueWithSections(
-            requesterId, request.toCommand(), sectionCommands
+            requesterId, request.toCommand(), sections
         );
 
         return ApiResponse.success(

--- a/src/main/java/com/firstticket/venueservice/presentation/VenueController.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/VenueController.java
@@ -284,11 +284,11 @@ public class VenueController {
         @PathVariable UUID sectionId,
         @PathVariable UUID seatId,
         @RequestBody @Valid UpdateSeatStatusRequest request) {
-        venueQueryService.validateSectionBelongsToVenue(venueId, sectionId);
-        venueQueryService.validateSeatBelongsToSection(sectionId, seatId);
-
         checkAdmin();
         UUID requesterId = AuthContext.getUserId();
+
+        venueQueryService.validateSectionBelongsToVenue(venueId, sectionId);
+        venueQueryService.validateSeatBelongsToSection(sectionId, seatId);
 
         UpdateVenueSeatStatusCommand command = request.toCommand(seatId);
         VenueSeatResult result = command.broken()

--- a/src/main/java/com/firstticket/venueservice/presentation/VenueInternalController.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/VenueInternalController.java
@@ -1,0 +1,56 @@
+package com.firstticket.venueservice.presentation;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.firstticket.common.response.ApiResponse;
+import com.firstticket.venueservice.application.service.VenueQueryService;
+import com.firstticket.venueservice.application.dto.result.SectionCapacityResult;
+import com.firstticket.venueservice.domain.VenueRepository;
+import com.firstticket.venueservice.domain.exception.VenueErrorCode;
+import com.firstticket.venueservice.domain.exception.VenueException;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Venue Service 내부 API Controller.
+ * Program Service의 VenueClient(Feign)가 호출하는 내부 전용 엔드포인트.
+ * 외부 사용자에게 노출하지 않는다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/venues")
+public class VenueInternalController {
+
+    private final VenueRepository venueRepository;
+    private final VenueQueryService venueQueryService;
+
+    /**
+     * 공연장 존재 여부 확인.
+     * Program Service의 스케줄 등록 시 공연장 존재 여부를 확인한다.
+     * 존재하면 200, 존재하지 않으면 404를 반환한다.
+     */
+    @GetMapping("/{venueId}/exists")
+    public ResponseEntity<Void> checkVenueExists(@PathVariable UUID venueId) {
+        if (!venueRepository.existsById(venueId)) {
+            throw new VenueException(VenueErrorCode.VENUE_NOT_FOUND);
+        }
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Section 수용 인원 상한 조회.
+     * Program Service의 addSectionCapacity() 호출 전 상한 검증에 사용한다.
+     */
+    @GetMapping("/sections/{sectionId}/capacity")
+    public ResponseEntity<ApiResponse<SectionCapacityResult>> getSectionCapacity(
+        @PathVariable UUID sectionId) {
+        SectionCapacityResult result = venueQueryService.getSectionCapacity(sectionId);
+        return ApiResponse.success(VenueSuccessCode.SECTION_CAPACITY_OK, result);
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/VenueInternalController.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/VenueInternalController.java
@@ -9,11 +9,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.firstticket.common.response.ApiResponse;
-import com.firstticket.venueservice.application.service.VenueQueryService;
 import com.firstticket.venueservice.application.dto.result.SectionCapacityResult;
-import com.firstticket.venueservice.domain.VenueRepository;
-import com.firstticket.venueservice.domain.exception.VenueErrorCode;
-import com.firstticket.venueservice.domain.exception.VenueException;
+import com.firstticket.venueservice.application.service.VenueQueryService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,7 +24,6 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/internal/v1/venues")
 public class VenueInternalController {
 
-    private final VenueRepository venueRepository;
     private final VenueQueryService venueQueryService;
 
     /**
@@ -37,9 +33,7 @@ public class VenueInternalController {
      */
     @GetMapping("/{venueId}/exists")
     public ResponseEntity<Void> checkVenueExists(@PathVariable UUID venueId) {
-        if (!venueRepository.existsById(venueId)) {
-            throw new VenueException(VenueErrorCode.VENUE_NOT_FOUND);
-        }
+        venueQueryService.validateVenueExists(venueId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/firstticket/venueservice/presentation/VenueSuccessCode.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/VenueSuccessCode.java
@@ -1,0 +1,35 @@
+package com.firstticket.venueservice.presentation;
+
+import org.springframework.http.HttpStatus;
+
+import com.firstticket.common.response.SuccessCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum VenueSuccessCode implements SuccessCode {
+
+    // --- Venue ------------------------------------------
+    VENUE_CREATED(HttpStatus.CREATED, "공연장이 등록되었습니다"),
+    VENUE_UPDATED(HttpStatus.OK, "공연장이 수정되었습니다"),
+    VENUE_DELETED(HttpStatus.NO_CONTENT, "공연장이 삭제되었습니다"),
+    VENUE_FOUND(HttpStatus.OK, "공연장을 조회했습니다"),
+    VENUE_LIST_FOUND(HttpStatus.OK, "공연장 목록을 조회했습니다"),
+
+    // ---- Section ------------------------------------------
+    SECTION_CREATED(HttpStatus.CREATED, "구역이 등록되었습니다"),
+    SECTION_DELETED(HttpStatus.NO_CONTENT, "구역이 삭제되었습니다"),
+    SECTION_FOUND(HttpStatus.OK, "구역을 조회했습니다"),
+    SECTION_LIST_FOUND(HttpStatus.OK, "구역 목록을 조회했습니다"),
+    SECTION_CAPACITY_OK(HttpStatus.OK, "구역 수용 인원을 조회했습니다"),
+
+    // ----- VenueSeat ------------------------------------------
+    SEAT_FOUND(HttpStatus.OK, "좌석을 조회했습니다"),
+    SEAT_LIST_FOUND(HttpStatus.OK, "좌석 목록을 조회했습니다"),
+    SEAT_STATUS_UPDATED(HttpStatus.OK, "좌석 상태가 변경되었습니다");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/request/CreateSectionRequest.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/request/CreateSectionRequest.java
@@ -1,0 +1,37 @@
+package com.firstticket.venueservice.presentation.dto.request;
+
+import java.util.UUID;
+
+import com.firstticket.venueservice.application.dto.command.CreateSectionCommand;
+import com.firstticket.venueservice.domain.SeatType;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 구역 등록 요청 DTO.
+ * 타입별 필수 파라미터:
+ * - SEATED   : rowCount, colCount 필수
+ * - STANDING : capacity 필수
+ * - FREE     : capacity 필수
+ * 타입별 파라미터 유효성은 도메인에서 검증한다.
+ */
+public record CreateSectionRequest(
+
+    @NotBlank(message = "구역명은 필수입니다")
+    String name,
+
+    @NotNull(message = "구역 타입은 필수입니다")
+    SeatType type,
+
+    Integer rowCount,   // SEATED 전용
+    Integer colCount,   // SEATED 전용
+    Integer capacity    // STANDING·FREE 전용
+
+) {
+    public CreateSectionCommand toCommand(UUID venueId) {
+        return new CreateSectionCommand(
+            venueId, name, type, rowCount, colCount, capacity
+        );
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/request/CreateVenueRequest.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/request/CreateVenueRequest.java
@@ -7,6 +7,7 @@ import com.firstticket.venueservice.application.dto.command.CreateVenueCommand;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * 공연장 등록 요청 DTO.
@@ -40,6 +41,7 @@ public record CreateVenueRequest(
         @NotBlank(message = "구역명은 필수입니다")
         String name,
 
+        @NotNull(message = "구역 타입은 필수입니다")
         com.firstticket.venueservice.domain.SeatType type,
 
         Integer rowCount,   // SEATED 전용

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/request/CreateVenueRequest.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/request/CreateVenueRequest.java
@@ -1,0 +1,56 @@
+package com.firstticket.venueservice.presentation.dto.request;
+
+import java.util.List;
+
+import com.firstticket.venueservice.application.dto.command.CreateSectionCommand;
+import com.firstticket.venueservice.application.dto.command.CreateVenueCommand;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 공연장 등록 요청 DTO.
+ * sections 배열을 함께 전달하면 구역과 VenueSeat이 자동 생성된다 (V-01, V-02).
+ */
+public record CreateVenueRequest(
+
+    @NotBlank(message = "공연장 이름은 필수입니다")
+    String name,
+
+    @NotBlank(message = "공연장 주소는 필수입니다")
+    String address,
+
+    @Valid
+    List<SectionRequest> sections  // null 허용 — 구역 없이 공연장만 생성 가능
+
+) {
+    public CreateVenueCommand toCommand() {
+        return new CreateVenueCommand(name, address);
+    }
+
+    /**
+     * 구역 등록 요청 내부 DTO.
+     * 타입별 필수 파라미터:
+     * - SEATED   : rowCount, colCount 필수 / capacity null
+     * - STANDING : capacity 필수 / rowCount, colCount null
+     * - FREE     : capacity 필수 / rowCount, colCount null
+     */
+    public record SectionRequest(
+
+        @NotBlank(message = "구역명은 필수입니다")
+        String name,
+
+        com.firstticket.venueservice.domain.SeatType type,
+
+        Integer rowCount,   // SEATED 전용
+        Integer colCount,   // SEATED 전용
+        Integer capacity    // STANDING·FREE 전용
+
+    ) {
+        public CreateSectionCommand toCommand(java.util.UUID venueId) {
+            return new CreateSectionCommand(
+                venueId, name, type, rowCount, colCount, capacity
+            );
+        }
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/request/SearchVenueRequest.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/request/SearchVenueRequest.java
@@ -2,15 +2,33 @@ package com.firstticket.venueservice.presentation.dto.request;
 
 import com.firstticket.venueservice.application.dto.query.VenueSearchQuery;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+
 /**
  * 공연장 목록 조회 요청 DTO.
  * toQuery()로 Application 계층의 VenueSearchQuery로 변환한다.
  */
 public record SearchVenueRequest(
     String keyword,
+
+    @Pattern(
+        regexp = "name|createdAt",
+        message = "정렬 필드는 name 또는 createdAt만 허용됩니다"
+    )
     String sort,
+
+    @Pattern(
+        regexp = "asc|desc",
+        flags = Pattern.Flag.CASE_INSENSITIVE,
+        message = "정렬 방향은 asc 또는 desc만 허용됩니다"
+    )
     String direction,
+
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
     int page,
+
+    @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다")
     int size
 ) {
     public VenueSearchQuery toQuery() {

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/request/SearchVenueRequest.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/request/SearchVenueRequest.java
@@ -1,0 +1,21 @@
+package com.firstticket.venueservice.presentation.dto.request;
+
+import com.firstticket.venueservice.application.dto.query.VenueSearchQuery;
+
+/**
+ * 공연장 목록 조회 요청 DTO.
+ * toQuery()로 Application 계층의 VenueSearchQuery로 변환한다.
+ */
+public record SearchVenueRequest(
+    String keyword,
+    String sort,
+    String direction,
+    int page,
+    int size
+) {
+    public VenueSearchQuery toQuery() {
+        return new VenueSearchQuery(
+            keyword, sort, direction, page, size
+        );
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/request/UpdateSeatStatusRequest.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/request/UpdateSeatStatusRequest.java
@@ -1,0 +1,26 @@
+package com.firstticket.venueservice.presentation.dto.request;
+
+import java.util.UUID;
+
+import com.firstticket.venueservice.application.dto.command.UpdateVenueSeatStatusCommand;
+import com.firstticket.venueservice.domain.PhysicalStatus;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 좌석 물리 상태 변경 요청 DTO.
+ * API 설계 문서: { physicalStatus: "AVAILABLE" | "BROKEN" }
+ */
+public record UpdateSeatStatusRequest(
+
+    @NotNull(message = "물리 상태는 필수입니다")
+    PhysicalStatus physicalStatus
+
+) {
+    public UpdateVenueSeatStatusCommand toCommand(UUID seatId) {
+        return new UpdateVenueSeatStatusCommand(
+            seatId,
+            physicalStatus == PhysicalStatus.BROKEN
+        );
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/request/UpdateVenueRequest.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/request/UpdateVenueRequest.java
@@ -1,0 +1,18 @@
+package com.firstticket.venueservice.presentation.dto.request;
+
+import java.util.UUID;
+
+import com.firstticket.venueservice.application.dto.command.UpdateVenueCommand;
+
+/**
+ * 공연장 수정 요청 DTO.
+ * null이면 기존 값 유지 (부분 업데이트).
+ */
+public record UpdateVenueRequest(
+    String name,
+    String address
+) {
+    public UpdateVenueCommand toCommand(UUID venueId) {
+        return new UpdateVenueCommand(venueId, name, address);
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/response/PagedResponse.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/response/PagedResponse.java
@@ -1,0 +1,28 @@
+package com.firstticket.venueservice.presentation.dto.response;
+
+import java.util.List;
+import java.util.function.Function;
+
+import com.firstticket.venueservice.domain.query.PagedResult;
+
+/**
+ * 페이지네이션 응답 DTO.
+ */
+public record PagedResponse<T>(
+    List<T> content,
+    long totalElements,
+    int totalPages,
+    int size,
+    int number
+) {
+    public static <S, T> PagedResponse<T> from(PagedResult<S> pagedResult,
+        Function<S, T> mapper) {
+        return new PagedResponse<>(
+            pagedResult.content().stream().map(mapper).toList(),
+            pagedResult.totalElements(),
+            pagedResult.totalPages(),
+            pagedResult.pageSize(),
+            pagedResult.pageNumber()
+        );
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/response/PagedResponse.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/response/PagedResponse.java
@@ -7,6 +7,11 @@ import com.firstticket.venueservice.domain.query.PagedResult;
 
 /**
  * 페이지네이션 응답 DTO.
+ *
+ * PagedResult 의존성:
+ * 현재 PagedResult는 domain/query에 위치하나
+ * presentation → domain 직접 의존을 피하려면 application 계층
+ * PagedResult를 별도로 두거나 공통 모듈로 분리한다.
  */
 public record PagedResponse<T>(
     List<T> content,

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/response/SectionResponse.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/response/SectionResponse.java
@@ -1,0 +1,33 @@
+package com.firstticket.venueservice.presentation.dto.response;
+
+import java.util.UUID;
+
+import com.firstticket.venueservice.application.dto.result.SectionResult;
+import com.firstticket.venueservice.domain.SeatType;
+
+/**
+ * 구역 조회 응답 DTO.
+ */
+public record SectionResponse(
+    UUID id,
+    String name,
+    SeatType type,
+    Integer rowCount,   // SEATED 전용
+    Integer colCount,   // SEATED 전용
+    Integer capacity,   // STANDING·FREE 전용
+    int seatCount       // SEATED: rowCount × colCount / STANDING·FREE: capacity
+) {
+    public static SectionResponse from(SectionResult result) {
+        return new SectionResponse(
+            result.id(),
+            result.name(),
+            result.type(),
+            result.rowCount(),
+            result.colCount(),
+            result.capacity(),
+            result.type() == SeatType.SEATED
+                ? result.rowCount() * result.colCount()
+                : result.capacity()
+        );
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/response/VenueResponse.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/response/VenueResponse.java
@@ -1,0 +1,27 @@
+package com.firstticket.venueservice.presentation.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.firstticket.venueservice.application.dto.result.VenueResult;
+
+/**
+ * 공연장 단건 조회 응답 DTO.
+ */
+public record VenueResponse(
+    UUID id,
+    String name,
+    String address,
+    List<SectionResponse> sections
+) {
+    public static VenueResponse from(VenueResult result) {
+        return new VenueResponse(
+            result.id(),
+            result.name(),
+            result.address(),
+            result.sections().stream()
+                .map(SectionResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/response/VenueSeatResponse.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/response/VenueSeatResponse.java
@@ -1,0 +1,27 @@
+package com.firstticket.venueservice.presentation.dto.response;
+
+import java.util.UUID;
+
+import com.firstticket.venueservice.application.dto.result.VenueSeatResult;
+import com.firstticket.venueservice.domain.PhysicalStatus;
+
+/**
+ * 좌석 조회 응답 DTO.
+ */
+public record VenueSeatResponse(
+    UUID id,
+    UUID sectionId,
+    int row,
+    int col,
+    PhysicalStatus physicalStatus
+) {
+    public static VenueSeatResponse from(VenueSeatResult result) {
+        return new VenueSeatResponse(
+            result.id(),
+            result.sectionId(),
+            result.row(),
+            result.col(),
+            result.physicalStatus()
+        );
+    }
+}

--- a/src/main/java/com/firstticket/venueservice/presentation/dto/response/VenueSummaryResponse.java
+++ b/src/main/java/com/firstticket/venueservice/presentation/dto/response/VenueSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.firstticket.venueservice.presentation.dto.response;
+
+import java.util.UUID;
+
+import com.firstticket.venueservice.application.dto.result.VenueSummaryResult;
+
+/**
+ * 공연장 목록 조회 응답 DTO.
+ */
+public record VenueSummaryResponse(
+    UUID id,
+    String name,
+    String address,
+    int sectionCount
+) {
+    public static VenueSummaryResponse from(VenueSummaryResult result) {
+        return new VenueSummaryResponse(
+            result.id(),
+            result.name(),
+            result.address(),
+            result.sectionCount()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V1_init_venue.sql
+++ b/src/main/resources/db/migration/V1_init_venue.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS p_venue
 -- 공연장명 검색 인덱스
 -- partial index: soft delete된 레코드 제외
 DO $$ BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_venue_name') THEN
+    IF NOT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.relname = 'idx_venue_name' AND n.nspname = 'program') THEN
 CREATE INDEX idx_venue_name ON program.p_venue (name) WHERE deleted_at IS NULL;
 END IF;
 END $$;
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS p_section
 
 -- 공연장별 구역 조회 인덱스
 DO $$ BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_section_venue_id') THEN
+    IF NOT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.relname = 'idx_section_venue_id' AND n.nspname = 'program') THEN
 CREATE INDEX idx_section_venue_id ON program.p_section (venue_id) WHERE deleted_at IS NULL;
 END IF;
 END $$;
@@ -151,10 +151,10 @@ CREATE TABLE IF NOT EXISTS p_venue_seat
 -- CreateSectionUseCase에서 VenueSeat 일괄 생성 후 조회 시 사용
 -- isAvailable() 선검증 쿼리에서 사용
 DO $$ BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_venue_seat_section_id') THEN
+    IF NOT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.relname = 'idx_venue_seat_section_id' AND n.nspname = 'program') THEN
 CREATE INDEX idx_venue_seat_section_id ON program.p_venue_seat (section_id) WHERE deleted_at IS NULL;
 END IF;
-    IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'idx_venue_seat_physical_status') THEN
+    IF NOT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid WHERE c.relname = 'idx_venue_seat_physical_status' AND n.nspname = 'program') THEN
 CREATE INDEX idx_venue_seat_physical_status ON program.p_venue_seat (physical_status) WHERE deleted_at IS NULL;
 END IF;
 END $$;


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- 공연장 서비스의 표현 계층 컨트롤러 및 dto 작성


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- #9 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [x] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)
- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 공연장 CRUD(생성—섹션·좌석 일괄 생성 옵션 포함, 검색(페이징·정렬), 조회, 부분 수정, 삭제) API 추가
  * 섹션 CRUD(생성·목록·단건 조회·삭제) 및 섹션 수용 인원 조회(내부용) API 추가
  * 섹션 내 좌석 목록·단건 조회 및 좌석 물리 상태(손상 표시/복구) 업데이트 API 추가
  * 페이징 응답·요약 응답 형식 및 일관된 성공 코드/메시지 추가
* **Refactor**
  * 역할 기반 접근 제어 및 공연장↔섹션↔좌석 관계 유효성 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->